### PR TITLE
Add batch HTML generation from directory of JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # VCAScribe-AuditRecords
+
+Utility for converting appointment JSON payloads into simple HTML reports.
+
+## Usage
+
+Process a single JSON file:
+
+    python generate_html.py input.json output.html
+
+Process a directory of JSON or text files (each containing JSON) and write the HTML reports to subfolders:
+
+    python generate_html.py input_dir results_dir
+
+Each input file produces `results_dir/<filename>/<filename>.html`.


### PR DESCRIPTION
## Summary
- allow `generate_html.py` to handle directories of .txt or .json files
- write each converted report to `results/<file>/<file>.html`
- document batch mode in README

## Testing
- `python -m py_compile generate_html.py`
- `python generate_html.py tmp_input/sample.txt output.html`
- `python generate_html.py tmp_batch results`


------
https://chatgpt.com/codex/tasks/task_e_689d42e5b614832d8bf159f9d4296569