### PR TITLE
Use fixed records and results paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,31 @@ Utility for converting appointment JSON payloads into simple HTML reports.
 
 ## Usage
 
-Process a single JSON file:
-
-    python generate_html.py input.json output.html
-
-Process a directory of JSON or text files (each containing JSON) and write the HTML reports to subfolders:
-
-    python generate_html.py input_dir results_dir
-
-Each input file produces `results_dir/<filename>/<filename>.html`.
-
-### Folder layout
-
-The script expects you to provide explicit paths for the input and output folders. A common layout is:
-
-- Place the JSON or text files to be processed in a folder named `records` at the repository root:
-
-  `VCAScribe-AuditRecords/records/`
-
-- Choose a folder for the generated HTML, such as `results`, also at the repository root:
-
-  `VCAScribe-AuditRecords/results/`
-
-Run the command using these paths:
+Place the JSON or text files to be processed in a folder named `records` at
+the repository root:
 
 ```
-python generate_html.py records results
+VCAScribe-AuditRecords/
+├── generate_html.py
+├── records/
+└── ...
 ```
 
-Each JSON file in `records` will produce an HTML report in `results/<filename>/<filename>.html`.
+Running the script with no arguments converts every `.json` or `.txt` file in
+`records` and writes the HTML reports to `results/<filename>/<filename>.html`:
+
+```
+python generate_html.py
+```
+
+After execution the directory structure will resemble:
+
+```
+VCAScribe-AuditRecords/
+├── records/
+│   └── some_file.json
+├── results/
+│   └── some_file/
+│       └── some_file.html
+└── generate_html.py
+```

--- a/generate_html.py
+++ b/generate_html.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""
-generate_html.py
+"""Generate HTML reports from appointment JSON payloads.
 
-Usage:
-    python generate_html.py input.json output.html
-    python generate_html.py input_dir output_dir
+The script reads all ``.json`` or ``.txt`` files in the ``records`` directory
+and writes an HTML report for each into a matching subdirectory of
+``results``. It is designed to run with no command line arguments:
+
+```
+python generate_html.py
+```
 """
 import json
-import sys
 from pathlib import Path
 from html import escape
 
@@ -94,31 +96,23 @@ def process_file(src: Path, dest: Path) -> None:
     print(f"Report written to {dest}")
 
 
-def main():
-    if len(sys.argv) != 3:
-        print(
-            "Usage: python generate_html.py input.json output.html\n"
-            "       python generate_html.py input_dir output_dir"
-        )
-        sys.exit(1)
+def main() -> None:
+    """Convert all files in ``records`` to HTML in ``results``."""
+    src = Path("records")
+    dest = Path("results")
 
-    src = Path(sys.argv[1])
-    dest = Path(sys.argv[2])
+    if not src.exists() or not src.is_dir():
+        raise SystemExit("records directory not found")
 
-    if src.is_dir():
-        dest.mkdir(parents=True, exist_ok=True)
-        for file in src.iterdir():
-            if file.suffix.lower() not in {".json", ".txt"}:
-                continue
-            subdir = dest / file.stem
-            subdir.mkdir(parents=True, exist_ok=True)
-            out_file = subdir / (file.stem + ".html")
-            process_file(file, out_file)
-    else:
-        if dest.is_dir():
-            dest = dest / (src.stem + ".html")
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        process_file(src, dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for file in src.iterdir():
+        if file.suffix.lower() not in {".json", ".txt"}:
+            continue
+        subdir = dest / file.stem
+        subdir.mkdir(parents=True, exist_ok=True)
+        out_file = subdir / (file.stem + ".html")
+        process_file(file, out_file)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Simplify `generate_html.py` to automatically read from `records` and write to `results`
- Update README to describe the new zero-argument workflow

## Testing
- `python generate_html.py` (with sample input)

------
https://chatgpt.com/codex/tasks/task_e_689dfb34198c832da99fb5ad387f9072