### PR TITLE
Process all record files sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ VCAScribe-AuditRecords/
 ```
 
 Running the script with no arguments converts every `.json` or `.txt` file in
-`records` and writes the HTML reports to `results/<filename>/<filename>.html`:
+`records` (recursively) and writes an HTML report for each to a time-stamped
+subdirectory of `results`:
 
 ```
 python generate_html.py
@@ -28,7 +29,7 @@ VCAScribe-AuditRecords/
 ├── records/
 │   └── some_file.json
 ├── results/
-│   └── some_file/
+│   └── 20240605-123456/
 │       └── some_file.html
 └── generate_html.py
 ```

--- a/generate_html.py
+++ b/generate_html.py
@@ -411,9 +411,13 @@ def main() -> None:
     run_dir = dest_root / datetime.now().strftime("%Y%m%d-%H%M%S")
     run_dir.mkdir(parents=True, exist_ok=True)
 
-    for file in src.iterdir():
-        if file.suffix.lower() not in {".json", ".txt"}:
-            continue
+    files = sorted(
+        p
+        for p in src.rglob("*")
+        if p.is_file() and p.suffix.lower() in {".json", ".txt"}
+    )
+
+    for file in files:
         out_file = run_dir / (file.stem + ".html")
         process_file(file, out_file)
 


### PR DESCRIPTION
## Summary
- Recursively gather `.json` and `.txt` files in `records` and process them sequentially.
- Update README to document recursive search and time-stamped output directory.

## Testing
- `python generate_html.py`
- `python -m py_compile generate_html.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_689e3b64f828832da6a1eb131ae7b0d3